### PR TITLE
Implementa validação de entrada com Pydantic para ferramentas MCP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "mcp[cli]>=1.4.1",
     "httpx>=0.28.1",
     "python-dotenv>=1.0.1",
+    "pydantic>=2.0.0",
 ]
 
 [project.urls]

--- a/server.py
+++ b/server.py
@@ -1,4 +1,7 @@
 from mcp.server.fastmcp import FastMCP
+from pydantic import ValidationError
+from fastapi.responses import JSONResponse
+from fastapi import Request
 
 mcp = FastMCP("brasil_api")
 
@@ -8,6 +11,13 @@ from src.tools.ddd import get_ddd_info
 from src.tools.feriados import get_feriados_info
 from src.tools.cambio import get_lista_cambio, get_cambio_info
 from src.tools.banco import get_lista_banco, get_banco_info
+
+@mcp.app.exception_handler(ValidationError)
+async def pydantic_validation_exception_handler(request: Request, exc: ValidationError):
+    return JSONResponse(
+        status_code=400,
+        content={"detail": exc.errors()}
+    )
 
 @mcp.tool()
 async def consultar_cep(cep: str):
@@ -21,7 +31,7 @@ async def consultar_cep(cep: str):
         dict: Um dicionário contendo informações relacionadas ao CEP fornecido.
         
     Raises:
-        ValueError: Se o CEP fornecido não estiver no formato correto.
+        ValidationError: Se o CEP fornecido não estiver no formato correto.
     """
     return await get_cep_info(cep)
 

--- a/src/tools/cep.py
+++ b/src/tools/cep.py
@@ -4,8 +4,9 @@ Ferramenta para consulta de CEP
 
 from typing import List, Dict, Any
 from ..utils.api import make_request
-from ..utils.validators import is_valid_cep
 from ..utils.formatters import format_cep
+from .schemas import ConsultarCepInput
+from pydantic import ValidationError
 
 async def get_cep_info(cep: str) -> List[Dict[str, Any]]:
     """
@@ -18,13 +19,9 @@ async def get_cep_info(cep: str) -> List[Dict[str, Any]]:
         List[Dict[str, Any]]: Uma lista de dicionários contendo informações relacionadas ao CEP.
 
     Raises:
-        ValueError: Se o CEP fornecido não estiver no formato correto.
+        ValidationError: Se o CEP fornecido não estiver no formato correto.
     """
-    
+    # Validação com Pydantic
+    ConsultarCepInput(cep=cep)
     formatted_cep = format_cep(cep)
-
-    if not is_valid_cep(formatted_cep):
-        raise ValueError("CEP inválido. O CEP deve ter 8 dígitos numéricos.")
-    
-    
     return await make_request("cep", formatted_cep)

--- a/src/tools/schemas.py
+++ b/src/tools/schemas.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel, constr
+
+class ConsultarCepInput(BaseModel):
+    cep: constr(min_length=8, max_length=8, pattern=r'^\d{8}$')

--- a/tests/test_cep_schema.py
+++ b/tests/test_cep_schema.py
@@ -1,0 +1,26 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
+
+import pytest
+from pydantic import ValidationError
+from src.tools.schemas import ConsultarCepInput
+
+def test_cep_valido():
+    data = ConsultarCepInput(cep="01001000")
+    assert data.cep == "01001000"
+
+def test_cep_invalido_tamanho():
+    with pytest.raises(ValidationError) as exc:
+        ConsultarCepInput(cep="1234567")
+    assert "string_too_short" in str(exc.value)
+
+def test_cep_invalido_letras():
+    with pytest.raises(ValidationError) as exc:
+        ConsultarCepInput(cep="abcdefgh")
+    assert "string_pattern_mismatch" in str(exc.value)
+
+def test_cep_invalido_caracteres_especiais():
+    with pytest.raises(ValidationError) as exc:
+        ConsultarCepInput(cep="12345-678")
+    assert "string_too_long" in str(exc.value)


### PR DESCRIPTION
Implementa validação de entrada com Pydantic para ferramentas MCP
Principais mudanças
Adiciona Pydantic como dependência do projeto.
Cria o modelo [ConsultarCepInput](https://miniature-yodel-jq59x7gr9wh5wwj.github.dev/) para validação do parâmetro [cep](https://miniature-yodel-jq59x7gr9wh5wwj.github.dev/) usando Pydantic.
Refatora a função [consultar_cep](https://miniature-yodel-jq59x7gr9wh5wwj.github.dev/) para utilizar o modelo Pydantic na validação dos dados de entrada.
Implementa handler global para [ValidationError](https://miniature-yodel-jq59x7gr9wh5wwj.github.dev/) do Pydantic, retornando HTTP 400 com detalhes dos erros de validação.
Adiciona testes unitários para garantir a validação correta do CEP.
Mantém compatibilidade com o padrão de resposta da Brasil API.
Como testar
Enviar requisições para a ferramenta [consultar_cep](https://miniature-yodel-jq59x7gr9wh5wwj.github.dev/) com CEPs válidos e inválidos.
Verificar se CEPs inválidos retornam erro HTTP 400 com detalhes.
Rodar os testes unitários:
Motivação
Padronizar e robustecer a validação de entrada das ferramentas MCP, facilitando manutenção, documentação e tratamento de erros.