### PR TITLE
refactor: tratamento de exceções customizadas para erros da Brasil AP…

### DIFF
--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,0 +1,19 @@
+class BrasilAPIError(Exception):
+    """Exceção base para erros relacionados à Brasil API."""
+    pass
+
+class BrasilAPINotFoundError(BrasilAPIError):
+    """Recurso não encontrado na Brasil API (HTTP 404)."""
+    pass
+
+class BrasilAPIInvalidRequestError(BrasilAPIError):
+    """Requisição inválida para a Brasil API (HTTP 400) ou erro de validação de negócio."""
+    pass
+
+class BrasilAPIServiceUnavailableError(BrasilAPIError):
+    """Serviço da Brasil API indisponível ou erro de servidor (HTTP 5xx)."""
+    pass
+
+class BrasilAPIUnknownError(BrasilAPIError):
+    """Erro inesperado da Brasil API ou durante o processamento."""
+    pass

--- a/src/tools/banco.py
+++ b/src/tools/banco.py
@@ -5,11 +5,24 @@ Ferramenta para consulta de cambio
 from typing import Dict, Any
 from ..utils.api import make_request
 from ..utils.formatters import format_data
+from ..exceptions import (
+    BrasilAPINotFoundError,
+    BrasilAPIInvalidRequestError,
+    BrasilAPIServiceUnavailableError,
+    BrasilAPIUnknownError,
+)
 
 async def get_lista_banco() -> Dict[str, Any]:
     """
-    Obtém informações de um banco brasileiro."""
-         
+    Obtém informações de bancos brasileiros.
+
+    Returns:
+        Dicionário com a lista de bancos.
+
+    Raises:
+        BrasilAPIServiceUnavailableError: Se a Brasil API estiver indisponível (HTTP 5xx) ou houver erro de rede.
+        BrasilAPIUnknownError: Para outros erros inesperados.
+    """
     return await make_request("lista_banco")
 
 async def get_banco_info(codigo: str) -> Dict[str, Any]:
@@ -21,5 +34,11 @@ async def get_banco_info(codigo: str) -> Dict[str, Any]:
 
     Returns:
         Dict[str, Any]: Informações do banco, incluindo ISPB, nome, código e nome completo.
+
+    Raises:
+        BrasilAPINotFoundError: Se o banco não for encontrado na Brasil API (HTTP 404).
+        BrasilAPIInvalidRequestError: Se a requisição para a Brasil API for inválida (HTTP 400).
+        BrasilAPIServiceUnavailableError: Se a Brasil API estiver indisponível (HTTP 5xx) ou houver erro de rede.
+        BrasilAPIUnknownError: Para outros erros inesperados.
     """
     return await make_request("banco", codigo)

--- a/src/tools/cambio.py
+++ b/src/tools/cambio.py
@@ -5,6 +5,12 @@ Ferramenta para consulta de câmbio
 from typing import Dict, Any
 from ..utils.api import make_request
 from ..utils.formatters import format_data
+from ..exceptions import (
+    BrasilAPINotFoundError,
+    BrasilAPIInvalidRequestError,
+    BrasilAPIServiceUnavailableError,
+    BrasilAPIUnknownError,
+)
 
 async def get_lista_cambio() -> Dict[str, Any]:
     """
@@ -12,6 +18,9 @@ async def get_lista_cambio() -> Dict[str, Any]:
        
     Returns:
         Um dicionário contendo informações relacionadas a moedas de câmbio.
+    Raises:
+        BrasilAPIServiceUnavailableError: Se a Brasil API estiver indisponível (HTTP 5xx) ou houver erro de rede.
+        BrasilAPIUnknownError: Para outros erros inesperados.
     """
     return await make_request("lista_cambio", "")
 
@@ -26,6 +35,11 @@ async def get_cambio_info(moeda: str, data: str) -> Dict[str, Any]:
 
     Returns:
         Dict[str, Any]: Dicionário contendo a cotação da moeda na data especificada.
+    Raises:
+        BrasilAPINotFoundError: Se a moeda não for encontrada (HTTP 404).
+        BrasilAPIInvalidRequestError: Se a requisição for inválida (HTTP 400).
+        BrasilAPIServiceUnavailableError: Se a Brasil API estiver indisponível (HTTP 5xx) ou houver erro de rede.
+        BrasilAPIUnknownError: Para outros erros inesperados.
     """
     formatted_data = format_data(data)
     return await make_request("cambio", moeda, formatted_data)

--- a/src/tools/cep.py
+++ b/src/tools/cep.py
@@ -7,6 +7,12 @@ from ..utils.api import make_request
 from ..utils.formatters import format_cep
 from .schemas import ConsultarCepInput
 from pydantic import ValidationError
+from ..exceptions import (
+    BrasilAPINotFoundError,
+    BrasilAPIInvalidRequestError,
+    BrasilAPIServiceUnavailableError,
+    BrasilAPIUnknownError,
+)
 
 async def get_cep_info(cep: str) -> List[Dict[str, Any]]:
     """
@@ -20,6 +26,10 @@ async def get_cep_info(cep: str) -> List[Dict[str, Any]]:
 
     Raises:
         ValidationError: Se o CEP fornecido não estiver no formato correto.
+        BrasilAPINotFoundError: Se o CEP não for encontrado na Brasil API (HTTP 404).
+        BrasilAPIInvalidRequestError: Se a requisição para a Brasil API for inválida (HTTP 400).
+        BrasilAPIServiceUnavailableError: Se o serviço da Brasil API estiver indisponível (HTTP 5xx) ou houver erro de rede.
+        BrasilAPIUnknownError: Para outros erros inesperados.
     """
     # Validação com Pydantic
     ConsultarCepInput(cep=cep)

--- a/src/tools/cnpj.py
+++ b/src/tools/cnpj.py
@@ -6,6 +6,12 @@ from typing import Dict, Any
 from ..utils.api import make_request
 from ..utils.formatters import format_document
 from ..utils.validators import is_valid_cnpj
+from ..exceptions import (
+    BrasilAPINotFoundError,
+    BrasilAPIInvalidRequestError,
+    BrasilAPIServiceUnavailableError,
+    BrasilAPIUnknownError,
+)
 
 async def get_cnpj_info(cnpj: str) -> Dict[str, Any]:
     """
@@ -16,6 +22,12 @@ async def get_cnpj_info(cnpj: str) -> Dict[str, Any]:
         
     Returns:
         Dicionário contendo informações relacionadas ao CNPJ fornecido
+    
+    Raises:
+        BrasilAPINotFoundError: Se o CNPJ não for encontrado na Brasil API (HTTP 404).
+        BrasilAPIInvalidRequestError: Se a requisição para a Brasil API for inválida (HTTP 400).
+        BrasilAPIServiceUnavailableError: Se a Brasil API estiver indisponível (HTTP 5xx) ou houver erro de rede.
+        BrasilAPIUnknownError: Para outros erros inesperados.
     """
     # Formatar o CNPJ removendo caracteres especiais
     formatted_cnpj = format_document(cnpj)

--- a/src/tools/ddd.py
+++ b/src/tools/ddd.py
@@ -5,6 +5,12 @@ Ferramenta para consulta de DDD
 from typing import Dict, Any, List
 from ..utils.api import make_request
 from ..utils.validators import is_valid_ddd
+from ..exceptions import (
+    BrasilAPINotFoundError,
+    BrasilAPIInvalidRequestError,
+    BrasilAPIServiceUnavailableError,
+    BrasilAPIUnknownError,
+)
 
 async def get_ddd_info(ddd: str) -> Dict[str, Any]:
     """
@@ -19,6 +25,10 @@ async def get_ddd_info(ddd: str) -> Dict[str, Any]:
         
     Raises:
         ValueError: Se o DDD fornecido não estiver no formato correto ou não for válido.
+        BrasilAPINotFoundError: Se o DDD não for encontrado na Brasil API (HTTP 404).
+        BrasilAPIInvalidRequestError: Se a requisição para a Brasil API for inválida (HTTP 400).
+        BrasilAPIServiceUnavailableError: Se a Brasil API estiver indisponível (HTTP 5xx) ou houver erro de rede.
+        BrasilAPIUnknownError: Para outros erros inesperados.
     """
     # Validação do DDD
     if not is_valid_ddd(ddd):

--- a/src/tools/feriados.py
+++ b/src/tools/feriados.py
@@ -5,6 +5,12 @@
 from typing import Dict, Any
 from ..utils.api import make_request
 from ..utils.validators import is_valid_year
+from ..exceptions import (
+    BrasilAPINotFoundError,
+    BrasilAPIInvalidRequestError,
+    BrasilAPIServiceUnavailableError,
+    BrasilAPIUnknownError,
+)
 
 async def get_feriados_info(year: str) -> Dict[str, Any]:
     """
@@ -19,6 +25,10 @@ async def get_feriados_info(year: str) -> Dict[str, Any]:
         
     Raises:
         ValueError: Se o ano fornecido não estiver no formato correto ou não for válido.
+        BrasilAPINotFoundError: Se o ano não for encontrado na Brasil API (HTTP 404).
+        BrasilAPIInvalidRequestError: Se a requisição para a Brasil API for inválida (HTTP 400).
+        BrasilAPIServiceUnavailableError: Se a Brasil API estiver indisponível (HTTP 5xx) ou houver erro de rede.
+        BrasilAPIUnknownError: Para outros erros inesperados.
     """
     # Valida o ano
     if not is_valid_year(year):

--- a/src/utils/api.py
+++ b/src/utils/api.py
@@ -6,6 +6,12 @@ import httpx
 from typing import Dict, Any
 
 from ..config import API_BASE_URL, API_PATHS, USER_AGENT
+from ..exceptions import (
+    BrasilAPINotFoundError,
+    BrasilAPIInvalidRequestError,
+    BrasilAPIServiceUnavailableError,
+    BrasilAPIUnknownError,
+)
 
 async def make_request(endpoint: str, *params: str) -> Dict[str, Any]:
     """
@@ -16,19 +22,21 @@ async def make_request(endpoint: str, *params: str) -> Dict[str, Any]:
         param: Parâmetro de caminho para o endpoint (ex: número do CEP ou CNPJ)
         
     Returns:
-        Dict contendo a resposta da API ou mensagem de erro
+        Dict contendo a resposta da API
+    
+    Raises:
+        BrasilAPINotFoundError: Se o recurso não for encontrado (404)
+        BrasilAPIInvalidRequestError: Se a requisição for inválida (400)
+        BrasilAPIServiceUnavailableError: Se a API estiver indisponível (5xx ou erro de rede)
+        BrasilAPIUnknownError: Para outros erros inesperados
     """
     path = API_PATHS.get(endpoint)
     if not path:
-        return {"error": f"Endpoint desconhecido: {endpoint}"}
+        raise BrasilAPIInvalidRequestError(f"Endpoint desconhecido: {endpoint}")
     
-    # Constrói a URL completa com o param como path parameter
-    #url = f"{API_BASE_URL}{path}{param}"
     # Junta os path params com barra, garantindo que estejam limpos e não vazios
     full_path = "/".join(str(param).strip().strip("/") for param in params if param)
     url = f"{API_BASE_URL}{path}{full_path}"
-
-    print(f"URL: {url}")
 
     async with httpx.AsyncClient() as client:
         try:
@@ -37,13 +45,24 @@ async def make_request(endpoint: str, *params: str) -> Dict[str, Any]:
                 headers={"User-Agent": USER_AGENT},
             )
             
-            if response.status_code == 200:
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status == 404:
+                raise BrasilAPINotFoundError(f"Recurso não encontrado na Brasil API: {e.request.url}") from e
+            elif status == 400:
                 try:
-                    return response.json()
-                except ValueError:
-                    return {"error": "Resposta JSON inválida"}
+                    detail = e.response.json().get("message", "Requisição inválida para a Brasil API")
+                except Exception:
+                    detail = "Requisição inválida para a Brasil API"
+                raise BrasilAPIInvalidRequestError(f"Erro na requisição para a Brasil API: {detail}") from e
+            elif 500 <= status < 600:
+                raise BrasilAPIServiceUnavailableError(f"Serviço da Brasil API indisponível: {status}") from e
             else:
-                return {"error": f"Requisição falhou com status {response.status_code}"}
+                raise BrasilAPIUnknownError(f"Erro inesperado da Brasil API: {status}") from e
         except httpx.RequestError as e:
-            return {"error": f"Erro na requisição: {str(e)}"}
+            raise BrasilAPIServiceUnavailableError(f"Erro de rede ou conexão ao chamar a Brasil API: {e}") from e
+        except Exception as e:
+            raise BrasilAPIUnknownError(f"Um erro inesperado ocorreu: {e}") from e
 


### PR DESCRIPTION
Contexto/Motivação:

Atualmente, o src/utils/api.py captura erros HTTP genéricos (httpx.HTTPStatusError). Embora isso seja útil, não fornece uma granularidade de erro suficiente para cenários específicos da Brasil API, como um recurso não encontrado (ex: um CEP ou CNPJ que não existe) ou um parâmetro de consulta inválido que escapou da validação Pydantic (embora Pydantic cubra muito, pode haver validações de lógica de negócio que a Brasil API faz). Além disso, as ferramentas podem precisar levantar seus próprios erros de lógica de negócio.

Objetivo:

Criar classes de exceção personalizadas para representar diferentes tipos de erros que podem surgir ao interagir com a Brasil API ou dentro da lógica das ferramentas MCP. Isso permitirá um tratamento de erros mais semântico, facilitando a depuração e o retorno de mensagens de erro mais claras para o cliente da API.

Descrição da Solução:

Criar um Módulo de Exceções:

Criar um novo arquivo src/exceptions.py (ou src/utils/exceptions.py, preferencialmente src/exceptions.py para ser mais genérico).
Definir uma classe base para todas as exceções personalizadas da Brasil API (ex: BrasilAPIError).
Definir exceções mais específicas que herdam da base:
BrasilAPINotFoundError(BrasilAPIError): Para quando um recurso não é encontrado (status 404).
BrasilAPIInvalidRequestError(BrasilAPIError): Para quando a requisição para a Brasil API é inválida (status 400) ou a validação de negócio falha após a validação Pydantic.
BrasilAPIServiceUnavailableError(BrasilAPIError): Para quando a Brasil API está fora do ar ou retorna um erro de servidor (status 5xx).
BrasilAPIUnknownError(BrasilAPIError): Para erros inesperados.
Modificar src/utils/api.py:

Atualizar a função make_request para levantar as novas exceções personalizadas com base nos códigos de status HTTP retornados pela Brasil API.
Exemplo:
Python

import httpx
from ..config import API_BASE_URL, API_PATHS
from ..exceptions import BrasilAPINotFoundError, BrasilAPIInvalidRequestError, BrasilAPIServiceUnavailableError, BrasilAPIUnknownError

async def make_request(path_key: str, param: str = None) -> dict:
try:
# ... (construção da URL)
response = await client.get(url, headers={"User-Agent": USER_AGENT})
response.raise_for_status() # Levanta httpx.HTTPStatusError para 4xx/5xx

    return response.json()

except httpx.HTTPStatusError as e:
    if e.response.status_code == 404:
        raise BrasilAPINotFoundError(f"Recurso não encontrado na Brasil API: {e.request.url}") from e
    elif e.response.status_code == 400:
        detail = e.response.json().get("message", "Requisição inválida para a Brasil API")
        raise BrasilAPIInvalidRequestError(f"Erro na requisição para a Brasil API: {detail}") from e
    elif 500 <= e.response.status_code < 600:
        raise BrasilAPIServiceUnavailableError(f"Serviço da Brasil API indisponível: {e.response.status_code}") from e
    else:
        raise BrasilAPIUnknownError(f"Erro inesperado da Brasil API: {e.response.status_code}") from e
except httpx.RequestError as e:
    raise BrasilAPIServiceUnavailableError(f"Erro de rede ou conexão ao chamar a Brasil API: {e}") from e
except Exception as e:
    raise BrasilAPIUnknownError(f"Um erro inesperado ocorreu: {e}") from e
Atualizar Ferramentas MCP (src/tools/*):

Modificar as funções get_*_info em cada ferramenta para importar e capturar as novas exceções, se necessário, ou permitir que elas sejam propagadas para o server.py para tratamento centralizado.
No caso da validação Pydantic, se for um ValidationError, ele já será capturado pelo manipulador existente no server.py.
Para erros retornados pela Brasil API (ex: 404 para CEP não encontrado), as ferramentas não precisarão mais de if not is_valid_cep(...) ou blocos try-except genéricos para HTTP, pois make_request já lançará a exceção semântica.
Exemplo Detalhado para a Ferramenta consultar_cep e src/utils/api.py:

Arquivo src/exceptions.py (Novo)

Python

class BrasilAPIError(Exception):
"""Base exception for Brasil API related errors."""
pass

class BrasilAPINotFoundError(BrasilAPIError):
"""Raised when a resource is not found (HTTP 404)."""
pass

class BrasilAPIInvalidRequestError(BrasilAPIError):
"""Raised for invalid requests to Brasil API (HTTP 400)."""
pass

class BrasilAPIServiceUnavailableError(BrasilAPIError):
"""Raised when Brasil API service is unavailable or returns a server error (HTTP 5xx)."""
pass

class BrasilAPIUnknownError(BrasilAPIError):
"""Raised for unexpected errors from Brasil API or during processing."""
pass
Modificação em src/utils/api.py:

Conforme o exemplo no item 2 da "Descrição da Solução", make_request será atualizado para levantar as novas exceções com base no status_code da resposta.
Modificação em src/tools/cep.py:

A função get_cep_info simplificará seu tratamento de erro:
Python

... (importações existentes, incluindo a nova from ..exceptions import BrasilAPINotFoundError)
from ..exceptions import BrasilAPINotFoundError # Adicionar esta linha
from .schemas import ConsultarCepInput

...
async def get_cep_info(cep: str) -> List[Dict[str, Any]]:
"""
Obtém informações de um CEP utilizando a Brasil API.
...
Raises:
ValidationError: Se o CEP fornecido não estiver no formato correto (do Pydantic).
BrasilAPINotFoundError: Se o CEP não for encontrado na Brasil API (HTTP 404).
BrasilAPIInvalidRequestError: Se a requisição para a Brasil API for inválida (HTTP 400).
BrasilAPIServiceUnavailableError: Se o serviço da Brasil API estiver indisponível (HTTP 5xx) ou houver erro de rede.
BrasilAPIUnknownError: Para outros erros inesperados.
"""
# Validação com Pydantic (já implementada)
ConsultarCepInput(cep=cep)
formatted_cep = format_cep(cep)

# make_request agora lançará as exceções customizadas
return await make_request("cep", formatted_cep)
No server.py, você precisará adicionar manipuladores de exceção para estas novas exceções, de forma semelhante ao ValidationError. Isso será abordado na próxima issue (feat: Retornar mensagens de erro mais específicas para cada ferramenta MCP).
Critérios de Aceitação:

Um novo módulo src/exceptions.py deve ser criado contendo as classes de exceção BrasilAPIError, BrasilAPINotFoundError, BrasilAPIInvalidRequestError, BrasilAPIServiceUnavailableError e BrasilAPIUnknownError.
A função make_request em src/utils/api.py deve ser refatorada para levantar estas exceções personalizadas com base nos códigos de status HTTP (404, 400, 5xx) e outros erros de rede/inesperados.
As funções get__info nas ferramentas (src/tools/) devem ser atualizadas para não mais realizar verificações de status HTTP diretas ou levantar ValueError genéricos para erros da Brasil API, dependendo das novas exceções.
Os testes unitários (a serem implementados em uma fase posterior) devem ser capazes de simular e testar o lançamento dessas novas exceções por make_request.
Tarefas (Checklist):

[ ] Criar o arquivo src/exceptions.py com as classes de exceção personalizadas.
[ ] Modificar src/utils/api.py:
Importar as novas classes de exceção.
Atualizar o bloco try-except para capturar httpx.HTTPStatusError e httpx.RequestError e levantar as exceções BrasilAPINotFoundError, BrasilAPIInvalidRequestError, BrasilAPIServiceUnavailableError, BrasilAPIUnknownError apropriadamente.
[ ] Refatorar src/tools/cep.py (e outras ferramentas, se quiser começar a aplicar) para remover qualquer lógica de tratamento de status HTTP direto e atualizar as docstrings para listar as novas exceções que podem ser propagadas.