### PR TITLE
feat: handlers de exceção HTTP para erros customizados da Brasil API …

### DIFF
--- a/server.py
+++ b/server.py
@@ -11,12 +11,46 @@ from src.tools.ddd import get_ddd_info
 from src.tools.feriados import get_feriados_info
 from src.tools.cambio import get_lista_cambio, get_cambio_info
 from src.tools.banco import get_lista_banco, get_banco_info
+from src.exceptions import (
+    BrasilAPINotFoundError,
+    BrasilAPIInvalidRequestError,
+    BrasilAPIServiceUnavailableError,
+    BrasilAPIUnknownError,
+)
 
 @mcp.app.exception_handler(ValidationError)
 async def pydantic_validation_exception_handler(request: Request, exc: ValidationError):
     return JSONResponse(
         status_code=400,
         content={"detail": exc.errors()}
+    )
+
+@mcp.app.exception_handler(BrasilAPINotFoundError)
+async def brasil_api_not_found_exception_handler(request: Request, exc: BrasilAPINotFoundError):
+    return JSONResponse(
+        status_code=404,
+        content={"detail": str(exc) if str(exc) else "Recurso não encontrado na Brasil API. Verifique o identificador fornecido."}
+    )
+
+@mcp.app.exception_handler(BrasilAPIInvalidRequestError)
+async def brasil_api_invalid_request_exception_handler(request: Request, exc: BrasilAPIInvalidRequestError):
+    return JSONResponse(
+        status_code=400,
+        content={"detail": str(exc) if str(exc) else "Requisição inválida para a Brasil API. Verifique os dados de entrada."}
+    )
+
+@mcp.app.exception_handler(BrasilAPIServiceUnavailableError)
+async def brasil_api_service_unavailable_exception_handler(request: Request, exc: BrasilAPIServiceUnavailableError):
+    return JSONResponse(
+        status_code=503,
+        content={"detail": str(exc) if str(exc) else "O serviço da Brasil API está temporariamente indisponível. Tente novamente mais tarde."}
+    )
+
+@mcp.app.exception_handler(BrasilAPIUnknownError)
+async def brasil_api_unknown_exception_handler(request: Request, exc: BrasilAPIUnknownError):
+    return JSONResponse(
+        status_code=500,
+        content={"detail": str(exc) if str(exc) else "Ocorreu um erro interno inesperado. Por favor, tente novamente ou contate o suporte."}
     )
 
 @mcp.tool()


### PR DESCRIPTION
Contexto/Motivação:

Na issue anterior, implementamos exceções personalizadas (BrasilAPINotFoundError, BrasilAPIInvalidRequestError, etc.) que são levantadas por src/utils/api.py. No entanto, essas exceções ainda precisam ser capturadas no nível do servidor MCP (server.py) e traduzidas em respostas HTTP claras e padronizadas para o cliente (LLM ou aplicação). Atualmente, o servidor só tem um manipulador para ValidationError do Pydantic. Precisamos estender esse tratamento para as novas exceções, garantindo que a experiência do usuário da API seja consistente e informativa.

Objetivo:

Implementar manipuladores de exceção no server.py para as exceções personalizadas da Brasil API (BrasilAPINotFoundError, BrasilAPIInvalidRequestError, BrasilAPIServiceUnavailableError, BrasilAPIUnknownError). Isso garantirá que o MCP retorne respostas HTTP apropriadas (404, 400, 503, 500) com mensagens de erro descritivas, melhorando a usabilidade da API para os consumidores.

Descrição da Solução:

Importar Exceções Personalizadas no server.py:

Adicionar as importações das classes de exceção de src/exceptions.py no server.py.
Criar Manipuladores de Exceção para Cada Tipo de Erro:

Usar @mcp.app.exception_handler() para cada uma das exceções personalizadas.

Cada manipulador deve retornar um JSONResponse com o status_code HTTP correspondente e uma mensagem no corpo da resposta (content).

BrasilAPINotFoundError (HTTP 404 - Not Found):

Exemplo de retorno: {"detail": "Recurso não encontrado. Verifique o identificador fornecido."}
BrasilAPIInvalidRequestError (HTTP 400 - Bad Request):

Exemplo de retorno: {"detail": "Parâmetro inválido ou requisição malformada. Verifique os dados de entrada."} (Pode reutilizar a mensagem da exceção).
BrasilAPIServiceUnavailableError (HTTP 503 - Service Unavailable):

Exemplo de retorno: {"detail": "O serviço da Brasil API está temporariamente indisponível. Tente novamente mais tarde."}
BrasilAPIUnknownError (HTTP 500 - Internal Server Error):

Exemplo de retorno: {"detail": "Ocorreu um erro interno inesperado. Por favor, tente novamente ou contate o suporte."}
Padronizar o Formato de Erro:

O formato de erro deve ser consistente com o já usado para ValidationError ({"detail": "..."} ou {"detail": [...]}). Recomenda-se manter {"detail": "mensagem de erro"} para a maioria dos casos e {"detail": list_of_errors} para Pydantic.
Exemplo Detalhado para server.py:

Python

server.py
from mcp.server.fastmcp import FastMCP
from pydantic import ValidationError
from fastapi.responses import JSONResponse
from fastapi import Request

Importar as exceções personalizadas
from src.exceptions import (
BrasilAPINotFoundError,
BrasilAPIInvalidRequestError,
BrasilAPIServiceUnavailableError,
BrasilAPIUnknownError,
)

mcp = FastMCP("brasil_api")

... (Importações das ferramentas existentes)
Handler para erros de validação Pydantic (já existente)
@mcp.app.exception_handler(ValidationError)
async def pydantic_validation_exception_handler(request: Request, exc: ValidationError):
return JSONResponse(
status_code=400,
content={"detail": exc.errors()}
)

Novo handler para BrasilAPINotFoundError (HTTP 404)
@mcp.app.exception_handler(BrasilAPINotFoundError)
async def brasil_api_not_found_exception_handler(request: Request, exc: BrasilAPINotFoundError):
return JSONResponse(
status_code=404,
content={"detail": str(exc) if str(exc) else "Recurso não encontrado na Brasil API. Verifique o identificador fornecido."}
)

Novo handler para BrasilAPIInvalidRequestError (HTTP 400)
@mcp.app.exception_handler(BrasilAPIInvalidRequestError)
async def brasil_api_invalid_request_exception_handler(request: Request, exc: BrasilAPIInvalidRequestError):
return JSONResponse(
status_code=400,
content={"detail": str(exc) if str(exc) else "Requisição inválida para a Brasil API. Verifique os dados de entrada."}
)

Novo handler para BrasilAPIServiceUnavailableError (HTTP 503)
@mcp.app.exception_handler(BrasilAPIServiceUnavailableError)
async def brasil_api_service_unavailable_exception_handler(request: Request, exc: BrasilAPIServiceUnavailableError):
return JSONResponse(
status_code=503, # 503 Service Unavailable é mais semântico para indisponibilidade
content={"detail": str(exc) if str(exc) else "O serviço da Brasil API está temporariamente indisponível. Tente novamente mais tarde."}
)

Novo handler para BrasilAPIUnknownError (HTTP 500)
@mcp.app.exception_handler(BrasilAPIUnknownError)
async def brasil_api_unknown_exception_handler(request: Request, exc: BrasilAPIUnknownError):
return JSONResponse(
status_code=500,
content={"detail": str(exc) if str(exc) else "Ocorreu um erro interno inesperado. Por favor, tente novamente ou contate o suporte."}
)

... (Definições das ferramentas MCP)
Critérios de Aceitação:

O server.py deve importar as classes de exceção de src/exceptions.py.
Devem ser adicionados manipuladores de exceção (@mcp.app.exception_handler) para BrasilAPINotFoundError, BrasilAPIInvalidRequestError, BrasilAPIServiceUnavailableError e BrasilAPIUnknownError.
Cada manipulador deve retornar um JSONResponse com o status_code HTTP apropriado (404, 400, 503, 500, respectivamente).
A mensagem de erro no detail do JSON deve ser descritiva e, preferencialmente, reutilizar a mensagem da exceção, caso ela exista.
(Opcional, mas recomendado para testes futuros): Simular chamadas que levantam essas exceções e verificar as respostas HTTP e o corpo do JSON.
Tarefas (Checklist):

[ ] Adicionar importações das exceções em server.py.
[ ] Implementar o exception_handler para BrasilAPINotFoundError retornando HTTP 404.
[ ] Implementar o exception_handler para BrasilAPIInvalidRequestError retornando HTTP 400.
[ ] Implementar o exception_handler para BrasilAPIServiceUnavailableError retornando HTTP 503.
[ ] Implementar o exception_handler para BrasilAPIUnknownError retornando HTTP 500.
Este Tech Spec se baseia na conclusão da issue anterior, onde as exceções foram criadas e levantadas. Agora, estamos garantindo que essas exceções sejam "apanhadas" no nível superior e traduzidas em uma resposta amigável para quem consome a API.