### PR TITLE
test: adiciona testes unitários para make_request em src/utils/api.py

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,71 @@
+import pytest
+import httpx
+from unittest.mock import patch
+from src.utils.api import make_request
+from src.exceptions import (
+    BrasilAPINotFoundError,
+    BrasilAPIInvalidRequestError,
+    BrasilAPIServiceUnavailableError,
+    BrasilAPIUnknownError,
+)
+
+@pytest.fixture(autouse=True)
+def mock_config():
+    with patch('src.config.API_BASE_URL', 'http://mock-api.com'), \
+         patch('src.config.API_PATHS', {'test_endpoint': '/test/'}), \
+         patch('src.config.USER_AGENT', 'test-agent'):
+        yield
+
+@pytest.mark.asyncio
+async def test_make_request_success(httpx_mock):
+    httpx_mock.add_response(url="http://mock-api.com/test/success", json={"data": "ok"}, status_code=200)
+    result = await make_request("test_endpoint", "success")
+    assert result == {"data": "ok"}
+
+@pytest.mark.asyncio
+async def test_make_request_not_found(httpx_mock):
+    httpx_mock.add_response(url="http://mock-api.com/test/notfound", status_code=404)
+    with pytest.raises(BrasilAPINotFoundError):
+        await make_request("test_endpoint", "notfound")
+
+@pytest.mark.asyncio
+async def test_make_request_invalid_request_400_with_message(httpx_mock):
+    httpx_mock.add_response(url="http://mock-api.com/test/invalid", json={"message": "Parametro inválido"}, status_code=400)
+    with pytest.raises(BrasilAPIInvalidRequestError) as excinfo:
+        await make_request("test_endpoint", "invalid")
+    assert "Parametro inválido" in str(excinfo.value)
+
+@pytest.mark.asyncio
+async def test_make_request_invalid_request_400_without_message(httpx_mock):
+    httpx_mock.add_response(url="http://mock-api.com/test/invalid2", status_code=400)
+    with pytest.raises(BrasilAPIInvalidRequestError) as excinfo:
+        await make_request("test_endpoint", "invalid2")
+    assert "Erro na requisição para a Brasil API" in str(excinfo.value)
+
+@pytest.mark.asyncio
+async def test_make_request_service_unavailable_500(httpx_mock):
+    httpx_mock.add_response(url="http://mock-api.com/test/server_error", status_code=500)
+    with pytest.raises(BrasilAPIServiceUnavailableError):
+        await make_request("test_endpoint", "server_error")
+
+@pytest.mark.asyncio
+async def test_make_request_network_error(httpx_mock):
+    httpx_mock.add_exception(httpx.RequestError("Network is down"))
+    with pytest.raises(BrasilAPIServiceUnavailableError) as excinfo:
+        await make_request("test_endpoint", "any_param")
+    assert "Erro de rede ou conexão" in str(excinfo.value)
+
+@pytest.mark.asyncio
+async def test_make_request_unknown_endpoint():
+    with pytest.raises(BrasilAPIInvalidRequestError) as excinfo:
+        await make_request("non_existent_endpoint_internal")
+    assert "Endpoint desconhecido" in str(excinfo.value)
+
+@pytest.mark.asyncio
+async def test_make_request_unexpected_error(monkeypatch):
+    async def raise_unexpected(*args, **kwargs):
+        raise Exception("Erro inesperado!")
+    monkeypatch.setattr("httpx.AsyncClient.get", raise_unexpected)
+    with pytest.raises(BrasilAPIUnknownError) as excinfo:
+        await make_request("test_endpoint", "any_param")
+    assert "Um erro inesperado ocorreu" in str(excinfo.value)


### PR DESCRIPTION
Contexto/Motivação:

O módulo src/utils/api.py é o componente central para todas as interações com a Brasil API. Ele é responsável por construir URLs, fazer requisições HTTP e, mais importante, tratar erros da API externa, convertendo-os em nossas exceções personalizadas. Atualmente, não há testes automatizados para make_request, o que significa que qualquer alteração nesse módulo ou na forma como a Brasil API responde pode introduzir bugs silenciosamente, afetando todas as ferramentas MCP.

Objetivo:

Implementar testes unitários robustos para a função make_request em src/utils/api.py. Esses testes devem verificar se a função:

Faz requisições HTTP corretamente para URLs válidas.
Lida com respostas de sucesso (HTTP 200).
Lança corretamente as exceções personalizadas (BrasilAPINotFoundError, BrasilAPIInvalidRequestError, BrasilAPIServiceUnavailableError, BrasilAPIUnknownError) para os respectivos códigos de status HTTP (404, 400, 5xx, outros) e erros de rede.
Descrição da Solução:

Ferramentas de Teste:

Continuar usando pytest.
Usar httpx.AsyncClient e httpx.Response para simular respostas da API.
Utilizar pytest-httpx para mockar as requisições HTTP realizadas por httpx.AsyncClient. Isso permite simular diferentes cenários de resposta da Brasil API sem realmente fazer chamadas de rede.
Estrutura dos Testes:

Criar um novo arquivo de teste: tests/test_api.py.
Importar pytest, httpx, e as funções/classes necessárias de src/utils/api.py e src/exceptions.py.
Cenários de Teste (Exemplos):

Sucesso (HTTP 200):

Testar se make_request retorna os dados JSON esperados quando a API responde com status 200.
Exemplo: make_request("cep", "01001000") deve retornar o JSON do CEP.
Erro de Recurso Não Encontrado (HTTP 404):

Mockar uma resposta HTTP 404 da Brasil API.
Verificar se make_request levanta BrasilAPINotFoundError.
Erro de Requisição Inválida (HTTP 400):

Mockar uma resposta HTTP 400 da Brasil API (com e sem corpo JSON de mensagem).
Verificar se make_request levanta BrasilAPIInvalidRequestError e se a mensagem de erro é capturada corretamente do JSON da resposta.
Erro de Serviço Indisponível (HTTP 5xx):

Mockar uma resposta HTTP 500, 503, etc., da Brasil API.
Verificar se make_request levanta BrasilAPIServiceUnavailableError.
Erro de Rede/Conexão:

Simular um httpx.RequestError (ex: falha de DNS, timeout de conexão).
Verificar se make_request levanta BrasilAPIServiceUnavailableError.
Erro Desconhecido/Inesperado:

Simular outros tipos de Exception genéricas que podem ocorrer.
Verificar se make_request levanta BrasilAPIUnknownError.
Endpoint Desconhecido (Interno):

Testar se make_request levanta BrasilAPIInvalidRequestError quando o endpoint fornecido não existe em API_PATHS.
Exemplo de Esboço de Código de Teste:

Python

tests/test_api.py
import pytest
import httpx
from httpx import Response
from unittest.mock import AsyncMock, patch

Importar a função a ser testada e as exceções
from src.utils.api import make_request
from src.exceptions import (
BrasilAPINotFoundError,
BrasilAPIInvalidRequestError,
BrasilAPIServiceUnavailableError,
BrasilAPIUnknownError,
)
from src.config import API_BASE_URL, API_PATHS, USER_AGENT # Necessário para mockar o config

Mockar as configurações para testes isolados
@pytest.fixture(autouse=True)
def mock_config():
with patch('src.config.API_BASE_URL', 'http://mock-api.com/'),
patch('src.config.API_PATHS', {'test_endpoint': '/test/{param}'}),
patch('src.config.USER_AGENT', 'test-agent'):
yield

@pytest.mark.asyncio
async def test_make_request_success(httpx_mock):
# Simula uma resposta de sucesso da API
httpx_mock.add_response(url="http://mock-api.com/test/some_param", json={"data": "success"}, status_code=200)

result = await make_request("test_endpoint", "some_param")
assert result == {"data": "success"}
@pytest.mark.asyncio
async def test_make_request_not_found(httpx_mock):
# Simula um erro 404 da API
httpx_mock.add_response(url="http://mock-api.com/test/non_existent", status_code=404)

with pytest.raises(BrasilAPINotFoundError):
    await make_request("test_endpoint", "non_existent")
@pytest.mark.asyncio
async def test_make_request_invalid_request_400_with_message(httpx_mock):
# Simula um erro 400 com mensagem no JSON
httpx_mock.add_response(url="http://mock-api.com/test/invalid_param", json={"message": "Parametro inválido"}, status_code=400)

with pytest.raises(BrasilAPIInvalidRequestError) as excinfo:
    await make_request("test_endpoint", "invalid_param")
assert "Parametro inválido" in str(excinfo.value)
@pytest.mark.asyncio
async def test_make_request_service_unavailable_500(httpx_mock):
# Simula um erro 500 da API
httpx_mock.add_response(url="http://mock-api.com/test/server_error", status_code=500)

with pytest.raises(BrasilAPIServiceUnavailableError):
    await make_request("test_endpoint", "server_error")
@pytest.mark.asyncio
async def test_make_request_network_error(httpx_mock):
# Simula um erro de rede
httpx_mock.add_exception(httpx.RequestError("Network is down"))

with pytest.raises(BrasilAPIServiceUnavailableError) as excinfo:
    await make_request("test_endpoint", "any_param")
assert "Erro de rede ou conexão" in str(excinfo.value)
@pytest.mark.asyncio
async def test_make_request_unknown_endpoint():
# Testa endpoint desconhecido configurado internamente
with pytest.raises(BrasilAPIInvalidRequestError) as excinfo:
await make_request("non_existent_endpoint_internal")
assert "Endpoint desconhecido" in str(excinfo.value)

... Adicionar mais testes para outros cenários ...
Critérios de Aceitação:

Um novo arquivo tests/test_api.py deve ser criado.
Os testes devem usar pytest e pytest-httpx para mockar as chamadas HTTP.
Deve haver testes cobrindo os cenários de sucesso (HTTP 200).
Deve haver testes para cada uma das exceções personalizadas levantadas por make_request (BrasilAPINotFoundError, BrasilAPIInvalidRequestError, BrasilAPIServiceUnavailableError, BrasilAPIUnknownError), verificando se a exceção correta é levantada para o status HTTP/tipo de erro correspondente.
Deve haver um teste para o cenário onde um endpoint desconhecido é passado para make_request (resultando em BrasilAPIInvalidRequestError).
Tarefas (Checklist):

[ ] Instalar pytest-httpx (pip install pytest-httpx).
[ ] Criar o arquivo tests/test_api.py.
[ ] Escrever testes para o cenário de sucesso de make_request.
[ ] Escrever testes para o cenário de BrasilAPINotFoundError (HTTP 404).
[ ] Escrever testes para o cenário de BrasilAPIInvalidRequestError (HTTP 400, com e sem corpo JSON de erro).
[ ] Escrever testes para o cenário de BrasilAPIServiceUnavailableError (HTTP 5xx e erro de rede).
[ ] Escrever testes para o cenário de BrasilAPIUnknownError (erros genéricos).
[ ] Escrever teste para endpoint desconhecido passado para make_request.