### PR TITLE
16 adicionar ferramenta mcp para consulta de taxaíndice oficial

### DIFF
--- a/.github/scripts/md_to_issue.py
+++ b/.github/scripts/md_to_issue.py
@@ -1,0 +1,39 @@
+import os
+import glob
+from github import Github
+import re
+
+REPO = os.environ.get('GITHUB_REPOSITORY')
+TOKEN = os.environ.get('GITHUB_TOKEN')
+ISSUES_PATH = 'docs/issues/*.md'
+
+if not TOKEN or not REPO:
+    print('GITHUB_TOKEN ou GITHUB_REPOSITORY não definidos.')
+    exit(1)
+
+g = Github(TOKEN)
+repo = g.get_repo(REPO)
+
+for md_file in glob.glob(ISSUES_PATH):
+    with open(md_file, encoding='utf-8') as f:
+        content = f.read()
+    # O título será a primeira linha não vazia, sem markdown
+    lines = [l.strip() for l in content.splitlines() if l.strip()]
+    if not lines:
+        continue
+    title = lines[0].replace('#', '').strip()
+    # Extrair labels se houver linha '**Labels:** ...'
+    labels = []
+    for l in lines:
+        m = re.match(r'\*\*Labels:\*\*\s*(.+)', l)
+        if m:
+            labels = [x.strip() for x in m.group(1).split(',') if x.strip()]
+            break
+    # Fechar issues abertas com o mesmo título
+    for issue in repo.get_issues(state='open'):
+        if issue.title == title:
+            issue.edit(state='closed')
+            print(f'Issue fechada: {title}')
+    # Criar nova issue
+    repo.create_issue(title=title, body=content, labels=labels)
+    print(f'Issue criada: {title} (labels: {labels})')

--- a/.github/workflows/issues-from-md.yml
+++ b/.github/workflows/issues-from-md.yml
@@ -1,0 +1,33 @@
+name: Issues automáticas a partir de Markdown
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'docs/issues/*.md'
+
+permissions:
+  issues: write
+
+jobs:
+  create-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout código
+        uses: actions/checkout@v4
+
+      - name: Instalar Python e dependências
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Instalar dependências Python
+        run: |
+          python -m pip install --upgrade pip
+          pip install PyGithub
+
+      - name: Criar issues a partir dos arquivos Markdown
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python .github/scripts/md_to_issue.py

--- a/docs/issues/padronizar-modelos-pydantic.md
+++ b/docs/issues/padronizar-modelos-pydantic.md
@@ -1,0 +1,16 @@
+# Importação de modelos Pydantic no server.py
+
+## Problema
+
+Atualmente, o arquivo `server.py` importa explicitamente o modelo `ConsultarTaxaInput` de `src.tools.schemas` para a ferramenta MCP `consultar_taxa_oficial`, mas não faz o mesmo para outros endpoints como CEP, CNPJ, etc., que também possuem validação de entrada.
+
+## Contexto
+
+- A ferramenta `consultar_taxa_oficial` recebe um objeto Pydantic como parâmetro, por isso a importação explícita.
+- As demais ferramentas MCP recebem tipos primitivos (ex: `cep: str`) e a validação ocorre internamente ou em outro ponto do fluxo.
+
+## Sugestão
+
+Padronizar o uso de modelos Pydantic para todos os endpoints MCP, tornando a validação explícita e centralizada, além de facilitar a documentação e o autocomplete.
+
+**Labels:** melhoria, arquitetura, validação


### PR DESCRIPTION
Para expandir as funcionalidades do MCP Brasil API e fornecer acesso a uma gama completa de dados econômicos, é essencial permitir a consulta de qualquer taxa de juros ou índice oficial disponível na Brasil API. A ferramenta anterior focava apenas na SELIC, mas a API oferece um endpoint genérico por sigla, o que permite uma abordagem mais versátil.

