### PR TITLE
Adicionar ferramenta MCP para listar veículos FIPE por marca e tipo

### DIFF
--- a/server.py
+++ b/server.py
@@ -12,8 +12,8 @@ from src.tools.feriados import get_feriados_info
 from src.tools.cambio import get_lista_cambio, get_cambio_info
 from src.tools.banco import get_lista_banco, get_banco_info
 from src.tools.taxas import get_taxa_info
-from src.tools.schemas import ConsultarTaxaInput, ListarMarcasFIPEInput
-from src.tools.fipe import get_tabelas_fipe, get_marcas_fipe
+from src.tools.schemas import ConsultarTaxaInput, ListarMarcasFIPEInput, ListarVeiculosFIPEInput
+from src.tools.fipe import get_tabelas_fipe, get_marcas_fipe, get_veiculos_fipe
 from src.exceptions import (
     BrasilAPINotFoundError,
     BrasilAPIInvalidRequestError,
@@ -218,6 +218,30 @@ async def listar_marcas_fipe(input_data: ListarMarcasFIPEInput):
         BrasilAPIUnknownError: Para outros erros inesperados.
     """
     return await get_marcas_fipe(input_data.tipo_veiculo, input_data.tabela_referencia)
+
+@mcp.tool()
+async def listar_veiculos_fipe(input_data: ListarVeiculosFIPEInput):
+    """
+    Lista os modelos de veículos FIPE para uma marca e tipo de veículo específicos.
+
+    Args:
+        input_data (ListarVeiculosFIPEInput): Objeto contendo tipo_veiculo, codigo_marca e tabela_referencia (opcional).
+
+    Returns:
+        list: Uma lista de dicionários, cada um representando um modelo FIPE.
+
+    Raises:
+        ValidationError: Se os parâmetros fornecidos não forem válidos.
+        BrasilAPINotFoundError: Se a marca, tipo de veículo ou tabela não for encontrada na Brasil API.
+        BrasilAPIInvalidRequestError: Se a requisição para a Brasil API for inválida.
+        BrasilAPIServiceUnavailableError: Se o serviço da Brasil API estiver indisponível.
+        BrasilAPIUnknownError: Para outros erros inesperados.
+    """
+    return await get_veiculos_fipe(
+        input_data.tipo_veiculo,
+        input_data.codigo_marca,
+        input_data.tabela_referencia
+    )
 
 if __name__ == "__main__":
     mcp.run()

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -93,3 +93,32 @@ tools:
       - BrasilAPIInvalidRequestError
       - BrasilAPIServiceUnavailableError
       - BrasilAPIUnknownError
+  listar_veiculos_fipe:
+    description: Lista os modelos de veículos disponíveis na Tabela FIPE para uma marca e tipo de veículo específicos.
+    parameters:
+      tipo_veiculo:
+        type: string
+        description: Tipo de veículo para listar os modelos (ex: 'carros', 'motos', 'caminhoes').
+        enum: ["caminhoes", "carros", "motos"]
+      codigo_marca:
+        type: integer
+        description: Código da marca FIPE. Pode ser obtido com 'listar_marcas_fipe'.
+      tabela_referencia:
+        type: integer
+        description: Código da tabela FIPE de referência (opcional). Se omitido, usará a tabela atual.
+        required: false
+    returns:
+      type: array
+      items:
+        type: object
+        properties:
+          nome:
+            type: string
+          valor:
+            type: integer
+    errors:
+      - ValidationError
+      - BrasilAPINotFoundError
+      - BrasilAPIInvalidRequestError
+      - BrasilAPIServiceUnavailableError
+      - BrasilAPIUnknownError

--- a/src/config.py
+++ b/src/config.py
@@ -16,5 +16,6 @@ API_PATHS = {
     "taxas": "/taxas/v1/",
     "tabelas_fipe": "/fipe/tabelas/v1/",  # NOVO PATH PARA TABELAS FIPE
     "marcas_fipe": "/fipe/marcas/v1/",   # NOVO PATH PARA MARCAS FIPE
+    "veiculos_fipe": "/fipe/veiculos/v1/",  # NOVO PATH PARA VEÍCULOS FIPE
     # Add more API paths as needed
 }

--- a/src/tools/fipe.py
+++ b/src/tools/fipe.py
@@ -39,3 +39,24 @@ async def get_marcas_fipe(tipo_veiculo: str, tabela_referencia: Optional[int] = 
     """
     query_params = {"tabela_referencia": tabela_referencia} if tabela_referencia is not None else None
     return await make_request("marcas_fipe", tipo_veiculo, query_params=query_params)
+
+async def get_veiculos_fipe(tipo_veiculo: str, codigo_marca: int, tabela_referencia: Optional[int] = None) -> List[Dict[str, Any]]:
+    """
+    Obtém a lista de veículos FIPE para uma marca e tipo de veículo específicos.
+
+    Args:
+        tipo_veiculo (str): O tipo de veículo (ex: 'carros', 'motos', 'caminhoes').
+        codigo_marca (int): Código da marca FIPE.
+        tabela_referencia (Optional[int]): Código da tabela FIPE de referência (opcional).
+
+    Returns:
+        List[Dict[str, Any]]: Uma lista de dicionários, cada um representando um veículo FIPE.
+
+    Raises:
+        BrasilAPINotFoundError: Se a marca, tipo de veículo ou tabela não for encontrada.
+        BrasilAPIInvalidRequestError: Se a requisição for inválida.
+        BrasilAPIServiceUnavailableError: Se a Brasil API estiver indisponível.
+        BrasilAPIUnknownError: Para outros erros inesperados.
+    """
+    query_params = {"tabela_referencia": tabela_referencia} if tabela_referencia is not None else None
+    return await make_request("veiculos_fipe", tipo_veiculo, str(codigo_marca), query_params=query_params)

--- a/src/tools/schemas.py
+++ b/src/tools/schemas.py
@@ -21,3 +21,20 @@ class ListarMarcasFIPEInput(BaseModel):
         None,
         description="Código da tabela FIPE de referência (opcional). Se omitido, usará a tabela atual. Pode ser obtido com 'listar_tabelas_fipe'."
     )
+
+class ListarVeiculosFIPEInput(BaseModel):
+    """
+    Modelo de entrada para listar veículos FIPE por marca e tipo.
+    """
+    tipo_veiculo: Literal["caminhoes", "carros", "motos"] = Field(
+        ...,
+        description="Tipo de veículo para listar os modelos (ex: 'carros', 'motos', 'caminhoes')."
+    )
+    codigo_marca: int = Field(
+        ...,
+        description="Código da marca FIPE. Pode ser obtido com 'listar_marcas_fipe'."
+    )
+    tabela_referencia: Optional[int] = Field(
+        None,
+        description="Código da tabela FIPE de referência (opcional). Se omitido, usará a tabela atual. Pode ser obtido com 'listar_tabelas_fipe'."
+    )

--- a/tests/test_fipe.py
+++ b/tests/test_fipe.py
@@ -15,7 +15,7 @@ async def test_get_tabelas_fipe_success(monkeypatch):
             {"codigo": 271, "mes": "junho/2021"},
             {"codigo": 272, "mes": "julho/2021"}
         ]
-    monkeypatch.setattr("src.utils.api.make_request", mock_make_request)
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
     result = await get_tabelas_fipe()
     assert isinstance(result, list)
     assert result[0]["codigo"] == 271
@@ -25,7 +25,7 @@ async def test_get_tabelas_fipe_success(monkeypatch):
 async def test_get_tabelas_fipe_service_unavailable(monkeypatch):
     async def mock_make_request(api):
         raise BrasilAPIServiceUnavailableError()
-    monkeypatch.setattr("src.utils.api.make_request", mock_make_request)
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
     with pytest.raises(BrasilAPIServiceUnavailableError):
         await get_tabelas_fipe()
 
@@ -33,7 +33,7 @@ async def test_get_tabelas_fipe_service_unavailable(monkeypatch):
 async def test_get_tabelas_fipe_unknown_error(monkeypatch):
     async def mock_make_request(api):
         raise BrasilAPIUnknownError()
-    monkeypatch.setattr("src.utils.api.make_request", mock_make_request)
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
     with pytest.raises(BrasilAPIUnknownError):
         await get_tabelas_fipe()
 
@@ -44,7 +44,7 @@ async def test_get_marcas_fipe_success(monkeypatch):
             {"nome": "FIAT", "valor": 21},
             {"nome": "FORD", "valor": 22}
         ]
-    monkeypatch.setattr("src.utils.api.make_request", mock_make_request)
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
     result = await get_marcas_fipe("carros")
     assert isinstance(result, list)
     assert result[0]["nome"] == "FIAT"
@@ -55,7 +55,7 @@ async def test_get_marcas_fipe_with_tabela(monkeypatch):
     async def mock_make_request(endpoint, tipo_veiculo, query_params=None):
         assert query_params == {"tabela_referencia": 271}
         return [{"nome": "FIAT", "valor": 21}]
-    monkeypatch.setattr("src.utils.api.make_request", mock_make_request)
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
     result = await get_marcas_fipe("carros", 271)
     assert result[0]["nome"] == "FIAT"
 
@@ -63,7 +63,7 @@ async def test_get_marcas_fipe_with_tabela(monkeypatch):
 async def test_get_marcas_fipe_not_found(monkeypatch):
     async def mock_make_request(endpoint, tipo_veiculo, query_params=None):
         raise BrasilAPINotFoundError()
-    monkeypatch.setattr("src.utils.api.make_request", mock_make_request)
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
     with pytest.raises(BrasilAPINotFoundError):
         await get_marcas_fipe("carros")
 
@@ -71,7 +71,7 @@ async def test_get_marcas_fipe_not_found(monkeypatch):
 async def test_get_marcas_fipe_invalid_request(monkeypatch):
     async def mock_make_request(endpoint, tipo_veiculo, query_params=None):
         raise BrasilAPIInvalidRequestError()
-    monkeypatch.setattr("src.utils.api.make_request", mock_make_request)
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
     with pytest.raises(BrasilAPIInvalidRequestError):
         await get_marcas_fipe("carros")
 
@@ -79,7 +79,7 @@ async def test_get_marcas_fipe_invalid_request(monkeypatch):
 async def test_get_marcas_fipe_service_unavailable(monkeypatch):
     async def mock_make_request(endpoint, tipo_veiculo, query_params=None):
         raise BrasilAPIServiceUnavailableError()
-    monkeypatch.setattr("src.utils.api.make_request", mock_make_request)
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
     with pytest.raises(BrasilAPIServiceUnavailableError):
         await get_marcas_fipe("carros")
 
@@ -87,6 +87,91 @@ async def test_get_marcas_fipe_service_unavailable(monkeypatch):
 async def test_get_marcas_fipe_unknown_error(monkeypatch):
     async def mock_make_request(endpoint, tipo_veiculo, query_params=None):
         raise BrasilAPIUnknownError()
-    monkeypatch.setattr("src.utils.api.make_request", mock_make_request)
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
     with pytest.raises(BrasilAPIUnknownError):
         await get_marcas_fipe("carros")
+
+@pytest.mark.asyncio
+async def test_get_veiculos_fipe_success(monkeypatch):
+    async def mock_make_request(endpoint, tipo_veiculo, codigo_marca, query_params=None):
+        assert endpoint == "veiculos_fipe"
+        assert tipo_veiculo == "carros"
+        assert codigo_marca == "21"
+        assert query_params == {"tabela_referencia": 271}
+        return [
+            {"nome": "UNO MILLE", "valor": 1234},
+            {"nome": "PALIO", "valor": 5678}
+        ]
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
+    from src.tools.fipe import get_veiculos_fipe
+    result = await get_veiculos_fipe("carros", 21, 271)
+    assert isinstance(result, list)
+    assert result[0]["nome"] == "UNO MILLE"
+    assert result[1]["valor"] == 5678
+
+@pytest.mark.asyncio
+async def test_get_veiculos_fipe_no_tabela(monkeypatch):
+    async def mock_make_request(endpoint, tipo_veiculo, codigo_marca, query_params=None):
+        assert query_params is None
+        return [{"nome": "UNO MILLE", "valor": 1234}]
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
+    from src.tools.fipe import get_veiculos_fipe
+    result = await get_veiculos_fipe("carros", 21)
+    assert result[0]["nome"] == "UNO MILLE"
+
+@pytest.mark.asyncio
+async def test_get_veiculos_fipe_not_found(monkeypatch):
+    async def mock_make_request(endpoint, tipo_veiculo, codigo_marca, query_params=None):
+        raise BrasilAPINotFoundError()
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
+    from src.tools.fipe import get_veiculos_fipe
+    with pytest.raises(BrasilAPINotFoundError):
+        await get_veiculos_fipe("carros", 21)
+
+@pytest.mark.asyncio
+async def test_get_veiculos_fipe_invalid_request(monkeypatch):
+    async def mock_make_request(endpoint, tipo_veiculo, codigo_marca, query_params=None):
+        raise BrasilAPIInvalidRequestError()
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
+    from src.tools.fipe import get_veiculos_fipe
+    with pytest.raises(BrasilAPIInvalidRequestError):
+        await get_veiculos_fipe("carros", 21)
+
+@pytest.mark.asyncio
+async def test_get_veiculos_fipe_service_unavailable(monkeypatch):
+    async def mock_make_request(endpoint, tipo_veiculo, codigo_marca, query_params=None):
+        raise BrasilAPIServiceUnavailableError()
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
+    from src.tools.fipe import get_veiculos_fipe
+    with pytest.raises(BrasilAPIServiceUnavailableError):
+        await get_veiculos_fipe("carros", 21)
+
+@pytest.mark.asyncio
+async def test_get_veiculos_fipe_unknown_error(monkeypatch):
+    async def mock_make_request(endpoint, tipo_veiculo, codigo_marca, query_params=None):
+        raise BrasilAPIUnknownError()
+    monkeypatch.setattr("src.tools.fipe.make_request", mock_make_request)
+    from src.tools.fipe import get_veiculos_fipe
+    with pytest.raises(BrasilAPIUnknownError):
+        await get_veiculos_fipe("carros", 21)
+
+from src.tools.schemas import ListarVeiculosFIPEInput
+from pydantic import ValidationError
+
+def test_listar_veiculos_fipe_input_validation():
+    # tipo_veiculo inválido
+    try:
+        ListarVeiculosFIPEInput(tipo_veiculo="barco", codigo_marca=1)
+        assert False, "Deveria lançar ValidationError para tipo_veiculo inválido"
+    except ValidationError:
+        pass
+    # codigo_marca ausente
+    try:
+        ListarVeiculosFIPEInput(tipo_veiculo="carros")
+        assert False, "Deveria lançar ValidationError para codigo_marca ausente"
+    except ValidationError:
+        pass
+    # tipo_veiculo válido
+    obj = ListarVeiculosFIPEInput(tipo_veiculo="carros", codigo_marca=1)
+    assert obj.tipo_veiculo == "carros"
+    assert obj.codigo_marca == 1


### PR DESCRIPTION
Contexto/Motivação
Implementa a ferramenta listar_veiculos_fipe no MCP Brasil API, permitindo listar modelos de veículos FIPE por marca e tipo. Desenvolvido com foco em integração limpa e sem conflitos.

Principais mudanças
Novo modelo Pydantic: ListarVeiculosFIPEInput
Nova função: get_veiculos_fipe
Endpoint registrado: "veiculos_fipe"
Ferramenta MCP: listar_veiculos_fipe no server
Documentação: smithery.yaml atualizado
Testes automatizados: cobertura total em test_fipe.py
Integração validada: todos os testes passaram
Checklist
<input checked="" disabled="" type="checkbox"> Branch criada a partir da main atualizada
<input checked="" disabled="" type="checkbox"> Sincronização com a main antes do push final
<input checked="" disabled="" type="checkbox"> Todos os testes automatizados de FIPE passaram
<input checked="" disabled="" type="checkbox"> Documentação atualizada
<input checked="" disabled="" type="checkbox"> Sem duplicidade de modelos ou funções
<input checked="" disabled="" type="checkbox"> Padrão de nomenclatura e organização mantido
<input checked="" disabled="" type="checkbox"> Revisão manual dos arquivos alterados
Observações
Sincronize a branch com a main antes de aprovar/mesclar o PR.
Em caso de conflitos, priorize sempre a versão mais recente dos modelos, endpoints e testes.